### PR TITLE
chore(renovate): update config to match other repositories

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,5 +11,16 @@
   "rangeStrategy": "bump",
   "npm": {
     "commitMessageTopic": "{{prettyDepType}} {{depName}}"
-  }
+  },
+  "schedule": ["before 2am on monday"],
+  "packageRules": [
+    {
+      "matchDatasources": ["npm"],
+      "stabilityDays": 3
+    },
+    {
+      "matchDepTypes": ["engines", "peerDependencies"],
+      "rangeStrategy": "replace"
+    }
+  ]
 }


### PR DESCRIPTION
* Make Renovate schedule updates to the morning on mondays
* Enforce stability period of three days
* Change range strategy for peerDeps and engines